### PR TITLE
MySql platform doesn't work in case of multibyte encoding

### DIFF
--- a/yuniql-core/LocalVersion.cs
+++ b/yuniql-core/LocalVersion.cs
@@ -8,7 +8,7 @@ namespace Yuniql.Core
     /// </summary>
     public class LocalVersion
     {
-        private const int Maxlength = 512;
+        private const int Maxlength = 190;
 
         public LocalVersion()
         {

--- a/yuniql-platforms/mysql/MySqlDataService.cs
+++ b/yuniql-platforms/mysql/MySqlDataService.cs
@@ -61,7 +61,7 @@ namespace Yuniql.MySql
             => @"
                 CREATE TABLE __yuniqldbversion (
 	                sequence_id INT AUTO_INCREMENT PRIMARY KEY NOT NULL,
-	                version VARCHAR(512) NOT NULL,
+	                version VARCHAR(190) NOT NULL,
 	                applied_on_utc TIMESTAMP NOT NULL,
 	                applied_by_user VARCHAR(32) NOT NULL,
 	                applied_by_tool VARCHAR(32) NULL,


### PR DESCRIPTION
The MySql platform doesn't work for multibyte encodings (e.g. for utf8, utf8mb4). The limitation is the size of the varchar column "version" for which the unique contraint is to be created. The limit is 191 for utf8mb4 and 256 for utf8. Therefore, I am setting the maxlength to 190.