### PR TITLE
Proposed refactor of MigrationServiceFactory 

### DIFF
--- a/yuniql-cli/CommandLineService.cs
+++ b/yuniql-cli/CommandLineService.cs
@@ -9,13 +9,13 @@ namespace Yuniql.CLI
 {
     public class CommandLineService : ICommandLineService
     {
-        private IMigrationServiceFactory _migrationServiceFactory;
+        private Core.Factories.IMigrationServiceFactory _migrationServiceFactory;
         private readonly ILocalVersionService _localVersionService;
         private readonly IEnvironmentService _environmentService;
         private ITraceService _traceService;
 
         public CommandLineService(
-            IMigrationServiceFactory migrationServiceFactory,
+            Core.Factories.IMigrationServiceFactory migrationServiceFactory,
             ILocalVersionService localVersionService,
             IEnvironmentService environmentService,
             ITraceService traceService)

--- a/yuniql-cli/Program.cs
+++ b/yuniql-cli/Program.cs
@@ -16,7 +16,8 @@ namespace Yuniql
             var environmentService = new EnvironmentService();
             var traceService = new FileTraceService();
             var localVersionService = new LocalVersionService(traceService);
-            var migrationServiceFactory = new CLI.MigrationServiceFactory(traceService);
+            //var migrationServiceFactory = new CLI.MigrationServiceFactory(traceService);
+            var migrationServiceFactory = new Core.Factories.MigrationServiceFactory(traceService);
             var commandLineService = new CommandLineService(migrationServiceFactory, localVersionService, environmentService, traceService);
 
             var resultCode = Parser.Default.ParseArguments<

--- a/yuniql-core/Factories/AssemblyTypeLoader.cs
+++ b/yuniql-core/Factories/AssemblyTypeLoader.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Yuniql.Core.Factories {
+    internal class AssemblyTypeLoader {
+         private static Dictionary<string, Assembly> _loadedAssemblies = new Dictionary<string, Assembly>();
+
+        public static bool DoesTypeExistInAssembly(Assembly assembly, string typeName) {
+            return assembly.GetTypes().Any(t => t.FullName == typeName);
+        }
+
+        public static Assembly ResolveAssembly(string assemblyName) {
+            if (_loadedAssemblies.ContainsKey(assemblyName)) {
+                return _loadedAssemblies[assemblyName];
+            }
+            else {
+                Assembly asm = null;
+                try {
+                    asm = Assembly.Load(assemblyName);
+                }
+                catch (Exception exc) {
+                    throw new AssemblyLoadFailedException(assemblyName, exc.Message);
+                }
+
+                _loadedAssemblies.Add(assemblyName, asm);
+                return asm;
+            }
+        }
+
+        public static T CreateInstance<T>(FullTypeNameEntry fullTypeNameEntry, object[] constructorArgs) where T : class {
+            return CreateInstance<T>(fullTypeNameEntry.AssemblyName, fullTypeNameEntry.TypeName, constructorArgs);
+        }
+
+        public static T CreateInstance<T>(string assemblyName, string typeName, object[] constructorArgs) where T : class {
+            var asm = ResolveAssembly(assemblyName);
+
+            T targetObject = null;
+            try {
+                targetObject = asm.CreateInstance(typeName, true, BindingFlags.CreateInstance, null,
+                               constructorArgs, null, null) as T;
+            }
+            catch (Exception exc) {
+                throw new TypeLoadFailedException(typeName, assemblyName, (exc.InnerException ?? exc).Message);
+            }
+
+            if (targetObject == null) throw new TypeLoadFailedException(typeName, assemblyName);
+
+            return targetObject;
+        }
+
+        public static object CreateInstance(string assemblyName, string typeName, object[] constructorArgs) {
+            var asm = ResolveAssembly(assemblyName);
+
+            var targetObject = asm.CreateInstance(typeName, true, BindingFlags.CreateInstance, null,
+                            constructorArgs, null, null);
+            if (targetObject == null) throw new TypeLoadFailedException(typeName, assemblyName);
+
+            return targetObject;
+        }
+
+    }
+
+    ///<inheritdoc/>
+    public struct FullTypeNameEntry {
+
+        ///<inheritdoc/>
+        public readonly string AssemblyName;
+        
+        ///<inheritdoc/>
+        public readonly string TypeName;
+
+        ///<inheritdoc/>
+        public FullTypeNameEntry(string fullTypeName) {
+            if (string.IsNullOrWhiteSpace(fullTypeName)) throw new MissingTypeNameException();
+
+            var nameParts = fullTypeName.Split(',');
+            if (nameParts.Length != 2) throw new InvalidTypeNameFormatException(fullTypeName, nameParts.Length);
+
+            AssemblyName = nameParts[0].Trim();
+            TypeName = nameParts[1].Trim();
+        }
+    }
+
+    ///<inheritdoc/>
+    public class MissingTypeNameException : ArgumentException {
+        
+        ///<inheritdoc/>
+        public MissingTypeNameException() 
+            : base("TypeName should not be null or empty"){
+
+        }
+    }
+
+    ///<inheritdoc/>
+    public class InvalidTypeNameFormatException : ArgumentException {
+        
+        ///<inheritdoc/>
+        public InvalidTypeNameFormatException(string typeName, int segmentCount)
+              : base($"Expected segment for {typeName} is 2 but actual is {segmentCount}") {
+        }
+    }
+
+        
+    ///<inheritdoc/>
+    public class TypeLoadFailedException : ArgumentException {
+        ///<inheritdoc/>
+        public TypeLoadFailedException(string typeName, string assemblyName)
+            : base($"Type {typeName} not found in assembly {assemblyName}") {
+
+        }
+
+        ///<inheritdoc/>
+        public TypeLoadFailedException(string typeName, string assemblyName, string message)
+           : base($"Type {typeName} not found in assembly {assemblyName}. Details: {message}") {
+
+        }
+    }
+
+    ///<inheritdoc/>
+    public class AssemblyLoadFailedException : ArgumentException {
+
+        ///<inheritdoc/>
+        public AssemblyLoadFailedException(string assemblyName, string errorDetails)
+            : base($"Assembly {assemblyName} not found. Details {errorDetails}") {
+
+        }
+    }
+}

--- a/yuniql-core/Factories/IMigrationServiceFactory.cs
+++ b/yuniql-core/Factories/IMigrationServiceFactory.cs
@@ -1,0 +1,8 @@
+﻿namespace Yuniql.Core.Factories {
+
+    ///<inheritdoc/>
+    public interface IMigrationServiceFactory {
+        ///<inheritdoc/>
+        IMigrationService Create(string platform);
+    }
+}

--- a/yuniql-core/Factories/MigrationServiceFactory.cs
+++ b/yuniql-core/Factories/MigrationServiceFactory.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using Yuniql.Extensibility;
+
+namespace Yuniql.Core.Factories {
+    ///<inheritdoc/>
+    public class MigrationServiceFactory : IMigrationServiceFactory {
+
+        private readonly Dictionary<string, MigrationServiceSourceAssemblies> _migrationServiceSourceAssemblies = new Dictionary<string, MigrationServiceSourceAssemblies>();
+        private readonly ITraceService _traceService;
+        
+        ///<inheritdoc/>
+        public MigrationServiceFactory(
+            ITraceService traceService)
+        {
+            this._traceService = traceService;
+
+            // TODO: Hard-coding the migration provider list for convenience but source definitions should be located in an external config file so that Yuniql.Core and 
+            // Yuniql.CLI do not need to be re-compiled or updated when a new migration provider is supported.
+            /* ex.
+                <platforms>
+                    <platform name="sqlserver">
+                        <dataServiceSourceAssembly>Yuniql.SqlServer,Yuniql.SqlServer.SqlServerDataService</dataServiceSourceAssembly>
+                        <bulkImportServieSourceAssembly>Yuniql.SqlServer,Yuniql.SqlServer.SqlServerBulkImportService</bulkImportServieSourceAssembly>
+                        <configurationServiceSourceAssembly>Yuniql.Core,Yuniql.Core.ConfigurationDataService</configurationServiceSourceAssembly>
+                    </platform>
+                    <platform name="mysql">
+                        etc...
+                    </platform>
+                </platforms>
+             */
+
+            _migrationServiceSourceAssemblies.Add(SUPPORTED_DATABASES.SQLSERVER, new MigrationServiceSourceAssemblies { 
+                DataServiceSourceAssembly = "Yuniql.SqlServer,Yuniql.SqlServer.SqlServerDataService",
+                BulkImportServiceSourceAssembly = "Yuniql.SqlServer,Yuniql.SqlServer.SqlServerBulkImportService",
+                ConfigurationServiceSourceAssembly = "Yuniql.Core,Yuniql.Core.ConfigurationDataService"
+            });
+        }
+
+        ///<inheritdoc/>
+        public IMigrationService Create(string platform)
+        {
+            // No more need for a switch statement here, and also no need for references to supported platform assemblies (current and future) 
+            // within YuniqlCore (which will result in circular references anyway).
+            // After a new supported platform is implemented, only the config file needs to be updated and the new supported binaries deployed.
+
+            if (!_migrationServiceSourceAssemblies.ContainsKey(platform.ToLower())) { 
+                throw new NotSupportedException($"The target database platform {platform} is not supported or plugins location was not correctly configured. " +
+                        $"See WIKI for supported database platforms and usage guide.");
+            }
+
+            var migrationServiceSourceAssembly = _migrationServiceSourceAssemblies[platform.ToLower()];
+            var dataServiceTypeInfo = new FullTypeNameEntry(migrationServiceSourceAssembly.DataServiceSourceAssembly);
+            var bulkImportServiceTypeInfo = new FullTypeNameEntry(migrationServiceSourceAssembly.BulkImportServiceSourceAssembly);
+            var configurationServiceTypeInfo = new FullTypeNameEntry(migrationServiceSourceAssembly.ConfigurationServiceSourceAssembly);
+
+            IDataService dataService = AssemblyTypeLoader.CreateInstance<IDataService>(dataServiceTypeInfo.AssemblyName, dataServiceTypeInfo.TypeName, new object[] { _traceService });
+            IBulkImportService bulkImportService = AssemblyTypeLoader.CreateInstance<IBulkImportService>(bulkImportServiceTypeInfo.AssemblyName, bulkImportServiceTypeInfo.TypeName, new object[] { _traceService });
+            
+            return dataService.IsAtomicDDLSupported
+                            ? CreateTransactionalMigrationService(dataService, bulkImportService, configurationServiceTypeInfo)
+                            : CreateNonTransactionalMigrationService(dataService, bulkImportService, configurationServiceTypeInfo);
+        }
+
+        private IMigrationService CreateTransactionalMigrationService(IDataService dataService, IBulkImportService bulkImportService, FullTypeNameEntry configurationServiceTypeInfo)
+        {
+            var localVersionService = new LocalVersionService(_traceService);
+            var tokenReplacementService = new TokenReplacementService(_traceService);
+            var directoryService = new DirectoryService();
+            var fileService = new FileService();
+
+            IConfigurationDataService configurationService = AssemblyTypeLoader.CreateInstance<IConfigurationDataService>(configurationServiceTypeInfo.AssemblyName, configurationServiceTypeInfo.TypeName, new object[] {dataService,  _traceService, tokenReplacementService });
+
+            var migrationService = new MigrationService(
+                localVersionService,
+                dataService,
+                bulkImportService,
+                configurationService,
+                tokenReplacementService,
+                directoryService,
+                fileService,
+                _traceService);
+            return migrationService;
+        }
+
+        private IMigrationService CreateNonTransactionalMigrationService(IDataService dataService, IBulkImportService bulkImportService, FullTypeNameEntry configurationServiceTypeInfo)
+        {
+            var localVersionService = new LocalVersionService(_traceService);
+            var tokenReplacementService = new TokenReplacementService(_traceService);
+            var directoryService = new DirectoryService();
+            var fileService = new FileService();
+
+            IConfigurationDataService configurationService = AssemblyTypeLoader.CreateInstance<IConfigurationDataService>(configurationServiceTypeInfo.AssemblyName, configurationServiceTypeInfo.TypeName, new object[] {dataService,  _traceService, tokenReplacementService });
+            var migrationService = new NonTransactionalMigrationService(
+                localVersionService,
+                dataService,
+                bulkImportService,
+                configurationService,
+                tokenReplacementService,
+                directoryService,
+                fileService,
+                _traceService);
+            return migrationService;
+        }
+    }
+
+    ///<inheritdoc/>
+    public struct MigrationServiceSourceAssemblies { 
+        ///<inheritdoc/>
+        public string DataServiceSourceAssembly { get; set; }
+        
+        ///<inheritdoc/>
+        public string BulkImportServiceSourceAssembly { get; set; }
+
+        ///<inheritdoc/>
+        public string ConfigurationServiceSourceAssembly { get; set; }
+    
+    }
+}


### PR DESCRIPTION
Hi @rdagumampan,

This PR is not intended to be merged as-is (for starters, the unit tests won't build) but rather just a starting point for a discussion on a proposed refactor of the MigrationServiceFactory implementation.

As I was analyzing how to add support for SQLite, it occurred to me that SQLite would need a different IConfigurationDataService implementation since it's a file-based database rather than a server-based one. For instance, checking for database existence and creating the database are file-check and file-create operations respectively (instead of executing SQL queries). 

Creating the SQLite-specific IConfigurationDataService is trivial but it's the MigrationServiceFactory implementation that's proving to be a challenge for the following reasons:
1. The concrete ConfigurationDataService implementation is created statically, which means one would need to add code conditions/switches on current platform to determine which specific type of IConfigurationDataService to create; this will make code harder to maintain over time.
2. Concrete IMigrationServiceFactory implementations are duplicated across projects where they are needed; this means any branching logic introduced by #1 should also be duplicated across.

Here are the key points in this PR that aim to address the challenges above:
1. There is a single MigrationServiceFactory, and it's located in Core (which I think is where it belongs); hence, there's no need to duplicate code.
2. Adding a new platform doesn't involve any changes in the MigrationServiceFactory code; only new entries to the config file are needed (open/closed principle). Although in this  PR, I hard-coded the dictionary of type definitions but they could easily be moved to config files since they are just simple strings; I pointed this out in the code comments as well. And one would notice that there's no longer a switch statement for the supported platforms.

Hope I explained things clearly; let me know what you think.  