### PR TITLE
Issue 122 add --required-cleared-draft option

### DIFF
--- a/yuniql-cli/CommandLineService.cs
+++ b/yuniql-cli/CommandLineService.cs
@@ -138,7 +138,8 @@ namespace Yuniql.CLI
                                      opts.ContinueAfterFailure
                     ? NonTransactionalResolvingOption.ContinueAfterFailure
                     : (NonTransactionalResolvingOption?)null,
-                                     opts.NoTransaction);
+                                     opts.NoTransaction,
+                                     opts.RequiredClearedDraft);
 
                 _traceService.Success($"Schema migration completed successfuly on {opts.Path}.");
                 return 0;

--- a/yuniql-cli/RunOption.cs
+++ b/yuniql-cli/RunOption.cs
@@ -13,5 +13,9 @@ namespace Yuniql.CLI
         //yuniql <command> --no-transaction
         [Option("no-transaction", Required = false, HelpText = "When set, migration will not use database transactions", Default = false)]
         public bool NoTransaction { get; set; }
+
+        //yuniql <command> --require-cleared-draft
+        [Option("require-cleared-draft", Required = false, HelpText = "When set, migration will fail when the _draft directory is not empty. This option is for production migration", Default = false)]
+        public bool RequiredClearedDraft { get; set; }
     }
 }

--- a/yuniql-core/IMigrationService.cs
+++ b/yuniql-core/IMigrationService.cs
@@ -10,7 +10,7 @@ namespace Yuniql.Core
     public interface IMigrationService
     {
         /// <summary>
-        /// Initializes the current instance of <see cref="MigrationService"./>
+        /// Initializes the current instance of <see cref="MigrationService"/>
         /// </summary>
         /// <param name="connectionString">Connection string to target database server or instance.</param>
         /// <param name="commandTimeout">Command timeout in seconds.</param>
@@ -45,6 +45,7 @@ namespace Yuniql.Core
         /// <param name="environmentCode">Environment code for environment-aware scripts.</param>
         /// <param name="resumeFromFailure">The resume from failure.</param>
         /// <param name="noTransaction">When TRUE, migration will run without using transactions</param>
+        /// <param name="requiredClearedDraftFolder">When TRUE, migration will fail if the _draft folder is not empty. This is for production migration</param>
         void Run(
             string workingPath, 
             string targetVersion = null, 
@@ -60,7 +61,8 @@ namespace Yuniql.Core
             string appliedByToolVersion = null,
             string environmentCode = null,
             NonTransactionalResolvingOption? resumeFromFailure = null,
-            bool noTransaction = false
+            bool noTransaction = false,
+            bool requiredClearedDraftFolder = false
         );
 
         /// <summary>
@@ -70,9 +72,20 @@ namespace Yuniql.Core
         /// <param name="tokens">Token kev/value pairs to replace tokens in script files.</param>
         /// <param name="commandTimeout">Command timeout in seconds.</param>
         /// <param name="environmentCode">Environment code for environment-aware scripts.</param>
-
         bool IsTargetDatabaseLatest(string targetVersion, string schemaName = null, string tableName = null);
 
+        /// <summary>
+        /// Runs migrations by executing alls scripts in the workspace directory. 
+        /// When CSV files are present also run bulk import operations to target database table having same file name.
+        /// </summary>
+        /// <param name="connection">The <see cref="IDbConnection"/> to use.</param>
+        /// <param name="transaction">The <see cref="IDbTransaction"/> to use</param>
+        /// <param name="workingPath">The directory path to migration project.</param>
+        /// <param name="tokenKeyPairs">Token kev/value pairs to replace tokens in script files.</param>
+        /// <param name="bulkSeparator">Bulk file values separator character in the CSV bulk import files. When NULL, uses comma.</param>
+        /// <param name="commandTimeout">Command timeout in seconds. When NULL, it uses default provider command timeout.</param>
+        /// <param name="environmentCode">Environment code for environment-aware scripts.</param>
+        /// <param name="requiredClearedDraftFolder">When TRUE, the migration will fail if the current folder is empty. This option is for production migration</param>
         void RunNonVersionScripts(
             IDbConnection connection,
             IDbTransaction transaction,
@@ -80,7 +93,8 @@ namespace Yuniql.Core
             List<KeyValuePair<string, string>> tokenKeyPairs = null,
             string bulkSeparator = null,
             int? commandTimeout = null,
-            string environmentCode = null
+            string environmentCode = null,
+            bool requiredClearedDraftFolder = false
         );
 
         void RunVersionScripts(

--- a/yuniql-core/NonTransactionalMigrationService.cs
+++ b/yuniql-core/NonTransactionalMigrationService.cs
@@ -66,7 +66,8 @@ namespace Yuniql.Core
             string appliedByToolVersion = null,
             string environmentCode = null,
             NonTransactionalResolvingOption? nonTransactionalResolvingOption = null,
-            bool noTransaction = false
+            bool noTransaction = false,
+            bool requiredClearedDraft = false
          )
         {
             if (_dataService.IsAtomicDDLSupported && nonTransactionalResolvingOption != null)

--- a/yuniql-tests/unit-tests/CommandLineServiceTests.cs
+++ b/yuniql-tests/unit-tests/CommandLineServiceTests.cs
@@ -263,6 +263,24 @@ namespace Yuniql.UnitTests
                           }, err => 1);
         }
 
+        [DataTestMethod]
+        [DataRow("--require-cleared-draft", true)]
+        [DataRow("", false)]
+        public void Test_Run_RequireClearedDraft_Default_To_False(string noRequireClearedDraftFlag, bool expectedSetting)
+        {
+            // arrange
+            var runVerbAttribute = Attribute.GetCustomAttribute(typeof(RunOption), typeof(VerbAttribute));
+            var runVerbName = ((VerbAttribute)runVerbAttribute).Name;
+            var args = new string[] { runVerbName, noRequireClearedDraftFlag };
+
+            // act-assert
+            Parser.Default.ParseArguments<RunOption>(args)
+                          .MapResult((RunOption sut) => {
+                              sut.RequiredClearedDraft.ShouldBe(expectedSetting);
+                              return 0;
+                          }, err => 1);
+        }
+
         [TestMethod]
         public void Test_Info_Option_No_Explicit_Options()
         {
@@ -312,7 +330,7 @@ namespace Yuniql.UnitTests
             var toolVersion = typeof(CommandLineService).Assembly.GetName().Version.ToString();
 
             migrationService.Verify(s => s.Initialize("sqlserver-connection-string", DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS));
-            migrationService.Verify(s => s.Run(@"c:\temp\yuniql", "v1.00", false, It.Is<List<KeyValuePair<string, string>>>(x => x.Count == 0), true, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false));
+            migrationService.Verify(s => s.Run(@"c:\temp\yuniql", "v1.00", false, It.Is<List<KeyValuePair<string, string>>>(x => x.Count == 0), true, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false, false));
         }
 
         [TestMethod]
@@ -346,7 +364,7 @@ namespace Yuniql.UnitTests
                     x[0].Key == "Token1" && x[0].Value == "TokenValue1"
                     && x[1].Key == "Token2" && x[1].Value == "TokenValue2"
                     && x[2].Key == "Token3" && x[2].Value == "TokenValue3"
-                ), true, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false));
+                ), true, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false, false));
         }
 
 
@@ -376,7 +394,7 @@ namespace Yuniql.UnitTests
             var toolVersion = typeof(CommandLineService).Assembly.GetName().Version.ToString();
 
             migrationService.Verify(s => s.Initialize("sqlserver-connection-string", DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS));
-            migrationService.Verify(s => s.Run(@"c:\temp\yuniql", "v1.00", false, It.Is<List<KeyValuePair<string, string>>>(x => x.Count == 0), false, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false));
+            migrationService.Verify(s => s.Run(@"c:\temp\yuniql", "v1.00", false, It.Is<List<KeyValuePair<string, string>>>(x => x.Count == 0), false, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false, false));
         }
 
         [TestMethod]
@@ -410,7 +428,7 @@ namespace Yuniql.UnitTests
                     x[0].Key == "Token1" && x[0].Value == "TokenValue1"
                     && x[1].Key == "Token2" && x[1].Value == "TokenValue2"
                     && x[2].Key == "Token3" && x[2].Value == "TokenValue3"
-                ), false, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false));
+                ), false, DEFAULT_CONSTANTS.BULK_SEPARATOR, null, null, DEFAULT_CONSTANTS.COMMAND_TIMEOUT_SECS, 0, toolName, toolVersion, null, null, false, false));
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Add  **--require-cleared-draft** option to fail the migration in production if the _draft folder is not empty, according to #122 issue