### PR TITLE
Honor YUNIQL_TARGET_PLATFORM environment var

### DIFF
--- a/yuniql-cli/BasePlatformOption.cs
+++ b/yuniql-cli/BasePlatformOption.cs
@@ -12,7 +12,7 @@ namespace Yuniql.CLI
         [Option("plugins-path", Required = false, HelpText = "The location of plugins. The default location is current location of the yuniql assemblies.")]
         public string PluginsPath { get; set; }
 
-        //yuniql <command> -c "<connectiong-string>"
+        //yuniql <command> -c "<connection-string>"
         [Option('c', "connection-string", Required = false, HelpText = "Connection string to target database server instance.")]
         public string ConnectionString { get; set; }
 

--- a/yuniql-cli/BasePlatformOption.cs
+++ b/yuniql-cli/BasePlatformOption.cs
@@ -5,7 +5,7 @@ namespace Yuniql.CLI
     public class BasePlatformOption : BaseOption
     {
         //yuniql <command> -d | --debug
-        [Option(longName: "platform", Required = false, HelpText = "Target database platform.", Default = "sqlserver")]
+        [Option(longName: "platform", Required = false, HelpText = "Target database platform. Default is sqlserver.")]
         public string Platform { get; set; }
 
         //yuniql <command> --plugins-path "," | --plugins-path "|"


### PR DESCRIPTION
The `sqlserver` default value defined in the `BasePlatformOption` CLI option definition means that the target platform is always already set when it's checked on [`CommandLineService.cs` line 92](https://github.com/rdagumampan/yuniql/blob/7755c3ebc33c7653fc47e8907206cc2dbc836aab/yuniql-cli/CommandLineService.cs#L92).

This prevents the environment variable YUNIQL_TARGET_PLATFORM from being able to provide a different default value on [`CommandLineService.cs` line 94](https://github.com/rdagumampan/yuniql/blob/7755c3ebc33c7653fc47e8907206cc2dbc836aab/yuniql-cli/CommandLineService.cs#L94).

By removing the default value from `BasePlatformOption`, the environment variable lookup in `CommandLineService.cs` works as expected.

Also, I fixed a comment typo in the same file. That's in a separate commit if you'd rather cherry-pick the functional change.