### PR TITLE
Add yuniql trace files to default `.gitignore`

### DIFF
--- a/yuniql-core/LocalVersionService.cs
+++ b/yuniql-core/LocalVersionService.cs
@@ -133,6 +133,7 @@ COPY . ./db
 yuniql.exe
 yuniql.pdb
 yuniqlx.exe
+yuniql-log-*.txt
 ");
                 _traceService.Info($"Created file {gitIgnoreFile}");
             }


### PR DESCRIPTION
I think the `.gitignore` file created by the `yuniql init` command should exclude yuniql's own activity log files by default.

This commit implements that behaviour, but it introduces a second location where the trace file name pattern is captured in the project. Perhaps it could be implemented more robustly by having a single point of definition for the log file naming convention.

[FileTraceService.cs line 72](https://github.com/rdagumampan/yuniql/blob/7755c3ebc33c7653fc47e8907206cc2dbc836aab/yuniql-core/FileTraceService.cs#L72) currently defines the trace file name format, but it's embedded in a private method.

`LocalVersionService`, which generates the `.gitignore` file, has access to an `ITraceService` interface already. I considered adding some kind of "FileNamePattern" property to that interface (since `FileTraceService` implements it) but I thought it might not be appropriate since some `ITraceService` implementations might log to a database or other non-file sinks instead.

I also considered adding `FileNamePattern` as a static member on `FileTraceService`, and then access that when generating the `.gitignore` file in `LocalVersionService`, but I thought you might not appreciate adding a hard dependency which bypasses your service dependency injection.

Let me know if you'd like me to submit one of those other approaches instead.