### PR TITLE
trace-directory & trace-silent parameters (Issue101)

### DIFF
--- a/yuniql-cli/BaseOption.cs
+++ b/yuniql-cli/BaseOption.cs
@@ -15,6 +15,10 @@ namespace Yuniql.CLI
         //yuniql <command> --trace-sensitive-data
         [Option("trace-sensitive-data", Required = false, HelpText = "Include sensitive data in the log.", Default = false)]
         public bool TraceSensitiveData { get; set; } = false;
+
+        //yuniql <command> --trace-directory
+        [Option("trace-directory", Required = false, HelpText = "Define the directory where the log files will be created.")]
+        public string TraceDirectory { get; set; }
     }
 
 }

--- a/yuniql-cli/BaseOption.cs
+++ b/yuniql-cli/BaseOption.cs
@@ -19,6 +19,10 @@ namespace Yuniql.CLI
         //yuniql <command> --trace-directory
         [Option("trace-directory", Required = false, HelpText = "Define the directory where the log files will be created.")]
         public string TraceDirectory { get; set; }
+
+        //yuniql <command> --trace-silent
+        [Option("trace-silent", Required = false, HelpText = "Disable the creation of log files.", Default = false)]
+        public bool IsTraceSilent { get; set; } = false;
     }
 
 }

--- a/yuniql-cli/Program.cs
+++ b/yuniql-cli/Program.cs
@@ -13,8 +13,8 @@ namespace Yuniql.CLI
 
         public static int Main(string[] args)
         {
-            var traceService = new FileTraceService();
             var directoryService = new DirectoryService();
+            var traceService = new FileTraceService(directoryService);
             var fileService = new FileService();
             var workspaceService = new WorkspaceService(traceService, directoryService, fileService);
 
@@ -74,6 +74,7 @@ namespace Yuniql.CLI
             Console.ResetColor();
 
             traceService.IsDebugEnabled = opts.IsDebug;
+            traceService.TraceDirectory = opts.TraceDirectory;
             traceService.IsTraceSensitiveData = opts.TraceSensitiveData;
 
             return command.Invoke(opts);

--- a/yuniql-cli/Program.cs
+++ b/yuniql-cli/Program.cs
@@ -76,6 +76,7 @@ namespace Yuniql.CLI
             traceService.IsDebugEnabled = opts.IsDebug;
             traceService.TraceDirectory = opts.TraceDirectory;
             traceService.IsTraceSensitiveData = opts.TraceSensitiveData;
+            traceService.IsTraceSilent = opts.IsTraceSilent;
 
             return command.Invoke(opts);
         }

--- a/yuniql-core/FileTraceService.cs
+++ b/yuniql-core/FileTraceService.cs
@@ -28,6 +28,9 @@ namespace Yuniql.Core
         public bool IsTraceSensitiveData { get; set; } = false;
 
         ///<inheritdoc/>
+        public bool IsTraceSilent { get; set; } = false;
+
+        ///<inheritdoc/>
         public string TraceDirectory 
         {
             get
@@ -53,10 +56,14 @@ namespace Yuniql.Core
         {
             if (IsDebugEnabled)
             {
-                var traceFile = GetTraceSessionFilePath();
                 var traceMessage = $"DBG   {DateTime.UtcNow.ToString("u")}   {message}{Environment.NewLine}";
 
-                File.AppendAllText(traceFile, traceMessage);
+                if (!IsTraceSilent)
+                {
+                    var traceFile = GetTraceSessionFilePath();
+                    File.AppendAllText(traceFile, traceMessage);
+                }
+
                 Console.ForegroundColor = ConsoleColor.DarkGray;
                 Console.Write(traceMessage);
                 Console.ResetColor();
@@ -66,10 +73,14 @@ namespace Yuniql.Core
         ///<inheritdoc/>
         public void Info(string message, object payload = null)
         {
-            var traceFile = GetTraceSessionFilePath();
             var traceMessage = $"INF   {DateTime.UtcNow.ToString("u")}   {message}{Environment.NewLine}";
 
-            File.AppendAllText(traceFile, traceMessage);
+            if (!IsTraceSilent)
+            {
+                var traceFile = GetTraceSessionFilePath();
+                File.AppendAllText(traceFile, traceMessage);
+            }
+
             Console.Write(traceMessage);
         }
 
@@ -77,10 +88,14 @@ namespace Yuniql.Core
         ///<inheritdoc/>
         public void Warn(string message, object payload = null)
         {
-            var traceFile = GetTraceSessionFilePath();
             var traceMessage = $"WRN   {DateTime.UtcNow.ToString("u")}   {message}{Environment.NewLine}";
 
-            File.AppendAllText(traceFile, traceMessage);
+            if (!IsTraceSilent)
+            {
+                var traceFile = GetTraceSessionFilePath();
+                File.AppendAllText(traceFile, traceMessage);
+            }
+
             Console.ForegroundColor = ConsoleColor.DarkYellow;
             Console.Write(traceMessage);
             Console.ResetColor();
@@ -89,10 +104,14 @@ namespace Yuniql.Core
         ///<inheritdoc/>
         public void Error(string message, object payload = null)
         {
-            var traceFile = GetTraceSessionFilePath();
             var traceMessage = $"ERR   {DateTime.UtcNow.ToString("u")}   {message}{Environment.NewLine}";
 
-            File.AppendAllText(traceFile, traceMessage);
+            if (!IsTraceSilent)
+            {
+                var traceFile = GetTraceSessionFilePath();
+                File.AppendAllText(traceFile, traceMessage);
+            }
+
             Console.ForegroundColor = ConsoleColor.Red;
             Console.Write(traceMessage);
             Console.ResetColor();
@@ -101,10 +120,14 @@ namespace Yuniql.Core
         ///<inheritdoc/>
         public void Success(string message, object payload = null)
         {
-            var traceFile = GetTraceSessionFilePath();
             var traceMessage = $"INF   {DateTime.UtcNow.ToString("u")}   {message}{Environment.NewLine}";
 
-            File.AppendAllText(traceFile, traceMessage);
+            if (!IsTraceSilent)
+            {
+                var traceFile = GetTraceSessionFilePath();
+                File.AppendAllText(traceFile, traceMessage);
+            }
+
             Console.ForegroundColor = ConsoleColor.Green;
             Console.Write(traceMessage);
             Console.ResetColor();

--- a/yuniql-core/FileTraceService.cs
+++ b/yuniql-core/FileTraceService.cs
@@ -10,9 +10,15 @@ namespace Yuniql.Core
     public class FileTraceService : ITraceService
     {
         private string _traceSessionId;
-        public FileTraceService()
+
+        private IDirectoryService _directoryService;
+
+        private string _traceDirectory;
+
+        public FileTraceService(IDirectoryService directoryService)
         {
             _traceSessionId = DateTime.Now.ToString("MMddyyyy-HHmmss");
+            _directoryService = directoryService;
         }
 
         ///<inheritdoc/>
@@ -21,6 +27,26 @@ namespace Yuniql.Core
         ///<inheritdoc/>
         public bool IsTraceSensitiveData { get; set; } = false;
 
+        ///<inheritdoc/>
+        public string TraceDirectory 
+        {
+            get
+            {
+                return _traceDirectory;
+            }
+            set
+            {
+                if (_directoryService.Exists(value))
+                {
+                    _traceDirectory = value;
+                }
+                else if (value!=null)
+                {
+                    Warn($"The provided trace directory does not exist. " +
+                        $"Generated logs will be saved in the current execution directory.");
+                }
+            }
+        }
 
         ///<inheritdoc/>
         public void Debug(string message, object payload = null)
@@ -86,7 +112,15 @@ namespace Yuniql.Core
 
         private string GetTraceSessionFilePath()
         {
-            return Path.Combine(Environment.CurrentDirectory, $"yuniql-log-{_traceSessionId}.txt");
+
+            if (TraceDirectory != null)
+            {
+                return Path.Combine(TraceDirectory, $"yuniql-log-{_traceSessionId}.txt");
+            }
+            else
+            {
+                return Path.Combine(Environment.CurrentDirectory, $"yuniql-log-{_traceSessionId}.txt");
+            }
         }
 
     }

--- a/yuniql-extensibility/ITraceService.cs
+++ b/yuniql-extensibility/ITraceService.cs
@@ -16,6 +16,11 @@
         bool IsTraceSensitiveData { get; set; }
 
         /// <summary>
+        /// This parameter allows users to define the directory where the log files will be created.
+        /// </summary>
+        string TraceDirectory { get; set; }
+
+        /// <summary>
         /// Writes debug messages.
         /// </summary>
         /// <param name="message">The message to write.</param>

--- a/yuniql-extensibility/ITraceService.cs
+++ b/yuniql-extensibility/ITraceService.cs
@@ -21,6 +21,11 @@
         string TraceDirectory { get; set; }
 
         /// <summary>
+        /// When true, the log creation is disabled.
+        /// </summary>
+        bool IsTraceSilent { get; set; }
+
+        /// <summary>
         /// Writes debug messages.
         /// </summary>
         /// <param name="message">The message to write.</param>

--- a/yuniql-tests/platform-tests/Core/BulkImportServiceTests.cs
+++ b/yuniql-tests/platform-tests/Core/BulkImportServiceTests.cs
@@ -19,6 +19,7 @@ namespace Yuniql.PlatformTests.Core
     {
         private ITestDataService _testDataService;
         private ITraceService _traceService;
+        private IDirectoryService _directoryService;
         private IMigrationServiceFactory _migrationServiceFactory;
         private TestConfiguration _testConfiguration;
 
@@ -32,7 +33,8 @@ namespace Yuniql.PlatformTests.Core
             _testDataService = testDataServiceFactory.Create(_testConfiguration.Platform);
 
             //create data service factory for migration proper
-            _traceService = new FileTraceService { IsDebugEnabled = true };
+            _directoryService = new DirectoryService();
+            _traceService = new FileTraceService(_directoryService) { IsDebugEnabled = true };
             _migrationServiceFactory = new MigrationServiceFactory(_traceService);
         }
 

--- a/yuniql-tests/platform-tests/Core/EnvironmentAwareMigrationTests.cs
+++ b/yuniql-tests/platform-tests/Core/EnvironmentAwareMigrationTests.cs
@@ -18,6 +18,7 @@ namespace Yuniql.PlatformTests.Core
         private ITestDataService _testDataService;
         private IMigrationServiceFactory _migrationServiceFactory;
         private ITraceService _traceService;
+        private IDirectoryService _directoryService;
         private TestConfiguration _testConfiguration;
 
         [TestInitialize]
@@ -30,7 +31,8 @@ namespace Yuniql.PlatformTests.Core
             _testDataService = testDataServiceFactory.Create(_testConfiguration.Platform);
 
             //create data service factory for migration proper
-            _traceService = new FileTraceService { IsDebugEnabled = true };
+            _directoryService = new DirectoryService();
+            _traceService = new FileTraceService(_directoryService) { IsDebugEnabled = true };
             _migrationServiceFactory = new MigrationServiceFactory(_traceService);
         }
 

--- a/yuniql-tests/platform-tests/Core/MigrationServiceTests.Mixed.cs
+++ b/yuniql-tests/platform-tests/Core/MigrationServiceTests.Mixed.cs
@@ -22,6 +22,7 @@ namespace Yuniql.PlatformTests.Core
         private ITestDataService _testDataService;
         private IMigrationServiceFactory _migrationServiceFactory;
         private ITraceService _traceService;
+        private IDirectoryService _directoryService;
         private TestConfiguration _testConfiguration;
 
         [TestInitialize]
@@ -34,7 +35,8 @@ namespace Yuniql.PlatformTests.Core
             _testDataService = testDataServiceFactory.Create(_testConfiguration.Platform);
 
             //create data service factory for migration proper
-            _traceService = new FileTraceService { IsDebugEnabled = true };
+            _directoryService = new DirectoryService();
+            _traceService = new FileTraceService(_directoryService) { IsDebugEnabled = true };
             _migrationServiceFactory = new MigrationServiceFactory(_traceService);
         }
 

--- a/yuniql-tests/platform-tests/Core/MigrationServiceTests.cs
+++ b/yuniql-tests/platform-tests/Core/MigrationServiceTests.cs
@@ -23,6 +23,7 @@ namespace Yuniql.PlatformTests.Core
         private ITestDataService _testDataService;
         private IMigrationServiceFactory _migrationServiceFactory;
         private ITraceService _traceService;
+        private IDirectoryService _directoryService;
         private TestConfiguration _testConfiguration;
 
         [TestInitialize]
@@ -35,7 +36,8 @@ namespace Yuniql.PlatformTests.Core
             _testDataService = testDataServiceFactory.Create(_testConfiguration.Platform);
 
             //create data service factory for migration proper
-            _traceService = new FileTraceService { IsDebugEnabled = true };
+            _directoryService = new DirectoryService();
+            _traceService = new FileTraceService(_directoryService) { IsDebugEnabled = true };
             _migrationServiceFactory = new MigrationServiceFactory(_traceService);
         }
 

--- a/yuniql-tests/platform-tests/Core/SqlBatchBreakdownTests.cs
+++ b/yuniql-tests/platform-tests/Core/SqlBatchBreakdownTests.cs
@@ -18,6 +18,7 @@ namespace Yuniql.PlatformTests.Core
         private ITestDataService _testDataService;
         private IMigrationServiceFactory _migrationServiceFactory;
         private ITraceService _traceService;
+        private IDirectoryService _directoryService;
         private TestConfiguration _testConfiguration;
 
         [TestInitialize]
@@ -30,7 +31,8 @@ namespace Yuniql.PlatformTests.Core
             _testDataService = testDataServiceFactory.Create(_testConfiguration.Platform);
 
             //create data service factory for migration proper
-            _traceService = new FileTraceService { IsDebugEnabled = true };
+            _directoryService = new DirectoryService();
+            _traceService = new FileTraceService(_directoryService) { IsDebugEnabled = true };
             _migrationServiceFactory = new MigrationServiceFactory(_traceService);
         }
 

--- a/yuniql-tests/platform-tests/Core/WorkspaceServiceTests.cs
+++ b/yuniql-tests/platform-tests/Core/WorkspaceServiceTests.cs
@@ -19,6 +19,7 @@ namespace Yuniql.PlatformTests.Core
         private ITestDataService _testDataService;
         private IMigrationServiceFactory _migrationServiceFactory;
         private ITraceService _traceService;
+        private IDirectoryService _directoryService;
         private TestConfiguration _testConfiguration;
         [TestInitialize]
         public void Setup()
@@ -30,7 +31,8 @@ namespace Yuniql.PlatformTests.Core
             _testDataService = testDataServiceFactory.Create(_testConfiguration.Platform);
 
             //create data service factory for migration proper
-            _traceService = new FileTraceService { IsDebugEnabled = true };
+            _directoryService = new DirectoryService();
+            _traceService = new FileTraceService(_directoryService) { IsDebugEnabled = true };
             _migrationServiceFactory = new MigrationServiceFactory(_traceService);
         }
 

--- a/yuniql-tests/platform-tests/Setup/TestConfiguration.cs
+++ b/yuniql-tests/platform-tests/Setup/TestConfiguration.cs
@@ -20,9 +20,9 @@ namespace Yuniql.PlatformTests.Setup
 
         public Configuration GetFreshConfiguration()
         {
-            var traceService = new FileTraceService();
-            var environmentService = new EnvironmentService();
             var directoryService = new DirectoryService();
+            var traceService = new FileTraceService(directoryService);
+            var environmentService = new EnvironmentService();
             var fileService = new FileService();
             var workspaceService = new WorkspaceService(traceService, directoryService, fileService);
             var configurationService = new ConfigurationService(environmentService, workspaceService, traceService);

--- a/yuniql-tests/platform-tests/Setup/TestDataCleanup.cs
+++ b/yuniql-tests/platform-tests/Setup/TestDataCleanup.cs
@@ -16,6 +16,7 @@ namespace Yuniql.PlatformTests.Setup
     {
         private ITestDataService _testDataService;
         private ITraceService _traceService;
+        private IDirectoryService _directoryService;
         private IMigrationServiceFactory _migrationServiceFactory;
         private TestConfiguration _testConfiguration;
 
@@ -29,7 +30,8 @@ namespace Yuniql.PlatformTests.Setup
             _testDataService = testDataServiceFactory.Create(_testConfiguration.Platform);
 
             //create data service factory for migration proper
-            _traceService = new FileTraceService { IsDebugEnabled = true };
+            _directoryService = new DirectoryService();
+            _traceService = new FileTraceService(_directoryService) { IsDebugEnabled = true };
             _migrationServiceFactory = new MigrationServiceFactory(_traceService);
         }
 

--- a/yuniql-tests/platform-tests/Setup/TestDataServiceFactory.cs
+++ b/yuniql-tests/platform-tests/Setup/TestDataServiceFactory.cs
@@ -23,7 +23,8 @@ namespace Yuniql.PlatformTests.Setup
 
         public ITestDataService Create(string platform)
         {
-            var traceService = new FileTraceService { IsDebugEnabled = true };
+            var directoryService = new DirectoryService();
+            var traceService = new FileTraceService(directoryService) { IsDebugEnabled = true };
             var tokenReplacementService = new TokenReplacementService(traceService);
 
             switch (platform.ToLower())

--- a/yuniql-tests/unit-tests/Setup/TestClassBase.cs
+++ b/yuniql-tests/unit-tests/Setup/TestClassBase.cs
@@ -12,9 +12,9 @@ namespace Yuniql.UnitTests
         [TestInitialize]
         public void Setup()
         {
-            var traceService = new FileTraceService();
-            var environmentService = new EnvironmentService();
             var directoryService = new DirectoryService();
+            var traceService = new FileTraceService(directoryService);
+            var environmentService = new EnvironmentService();
             var fileService = new FileService();
             var workspaceService = new WorkspaceService(traceService, directoryService, fileService);
             var configurationService = new ConfigurationService(environmentService, workspaceService, traceService);


### PR DESCRIPTION
**trace-silent parameter added as Base Option** 

- When true, no logs are being created

- False by default

**trace-directory parameter added as Base Option**

- If non existing path is provided in the parameter, a warning message will appear that the logs will be saved in the current execution directory
- DirectoryService has to be injected in the FileTraceService
- Updated Test Cases which are using the FileTraceService to inject the FileTraceService