### PR TITLE
Refactor handling of --trace-to-file and added --trace-directory #issue-260

### DIFF
--- a/yuniql-cli/BaseOption.cs
+++ b/yuniql-cli/BaseOption.cs
@@ -14,16 +14,19 @@ namespace Yuniql.CLI
 
         //yuniql <command> --trace-sensitive-data
         [Option("trace-sensitive-data", Required = false, HelpText = "Include sensitive data like connection string in the log messages.", Default = false)]
-        public bool IsTraceSensitiveData { get; set; } = false;
+        public bool IsTraceSensitiveData { get; set; }
 
         //https://peter.sh/experiments/chromium-command-line-switches/
         //yuniql <command> --trace-to-file
-        [Option("trace-to-file", Required = false, HelpText = "Trace logs are also written on file in addition to console output.", Default = true)]
-        public bool IsTraceToFile { get; set; } = true;
+        [Option("trace-to-file", Required = false, HelpText = "Trace logs are also written on file in addition to console output.", Default = false)]
+        public bool IsTraceToFile { get; set; }
 
         //yuniql <command> --trace-to-directory
-        [Option("trace-to-directory", Required = false, HelpText = "Directory path where the log files will be created.")]
-        public string TraceToDirectory { get; set; }
+        [Option("trace-to-directory", Required = false, HelpText = "Trace logs files are placed in specific directory using --trace-directory parameter.")]
+        public bool IsTraceToDirectory { get; set; }
 
+        //yuniql <command> --trace-to-directory
+        [Option("trace-directory", Required = false, HelpText = "Directory path where the log files will be created.")]
+        public string TraceDirectory { get; set; }
     }
 }

--- a/yuniql-cli/Program.cs
+++ b/yuniql-cli/Program.cs
@@ -85,7 +85,15 @@ namespace Yuniql.CLI
             traceService.IsDebugEnabled = opts.IsDebug;
             traceService.IsTraceSensitiveData = opts.IsTraceSensitiveData;
             traceService.IsTraceToFile = opts.IsTraceToFile;
-            traceService.TraceToDirectory = opts.TraceToDirectory;
+            traceService.IsTraceToDirectory = opts.IsTraceToDirectory;
+            traceService.TraceDirectory = opts.TraceDirectory;
+
+            if (!traceService.IsTraceToFile)
+            {
+                Console.ForegroundColor = ConsoleColor.DarkYellow;
+                Console.WriteLine($"WRN   {DateTime.UtcNow.ToString("u")}   Trace logs settings is set to silent (default) and no log files will be produced. To enable log file creation, pass parameter --trace-to-file or see our CLI command reference.");
+                Console.ResetColor();
+            }
 
             return command.Invoke(opts);
         }

--- a/yuniql-cli/Properties/launchSettings.json
+++ b/yuniql-cli/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Yuniql.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "run -a --debug"
+      "commandLineArgs": "run -a --debug --trace-to-file"
     }
   }
 }

--- a/yuniql-core/FileTraceService.cs
+++ b/yuniql-core/FileTraceService.cs
@@ -18,17 +18,20 @@ namespace Yuniql.Core
         }
 
         ///<inheritdoc/>
-        public bool IsDebugEnabled { get; set; } = false;
+        public bool IsDebugEnabled { get; set; }
 
         ///<inheritdoc/>
-        public bool IsTraceSensitiveData { get; set; } = false;
+        public bool IsTraceSensitiveData { get; set; }
 
         ///<inheritdoc/>
-        public bool IsTraceToFile { get; set; } = true;
+        public bool IsTraceToFile { get; set; }
+
+        ///<inheritdoc/>
+        public bool IsTraceToDirectory { get; set; }
 
         private string _traceDirectory;
         ///<inheritdoc/>
-        public string TraceToDirectory 
+        public string TraceDirectory 
         {
             get
             {
@@ -39,7 +42,7 @@ namespace Yuniql.Core
                 //when user specified location but it does not exist
                 if (value != null && !Directory.Exists(value))
                 {
-                    Warn($"The provided trace directory does not exist. " +
+                    Warn($"The provided trace directory {value} does not exist. " +
                         $"Generated logs will be saved in the current directory {Environment.CurrentDirectory}.");
                 } else if (Directory.Exists(value))
                 {
@@ -133,14 +136,22 @@ namespace Yuniql.Core
 
         private string GetTraceSessionFilePath()
         {
-            if (TraceToDirectory != null)
+            var traceFilePath = string.Empty;
+            if (IsTraceToDirectory && TraceDirectory != null)
             {
-                return Path.Combine(TraceToDirectory, $"yuniql-log-{_traceSessionId}.txt");
+                traceFilePath = Path.Combine(TraceDirectory, $"yuniql-log-{_traceSessionId}.txt");
             }
             else
             {
-                return Path.Combine(Environment.CurrentDirectory, $"yuniql-log-{_traceSessionId}.txt");
+                traceFilePath = Path.Combine(Environment.CurrentDirectory, $"yuniql-log-{_traceSessionId}.txt");
             }
+
+            if (!File.Exists(traceFilePath))
+            {
+                Console.WriteLine($"INF   {DateTime.UtcNow.ToString("u")}   Trace logs for the current session is located at {traceFilePath}.");
+            }
+
+            return traceFilePath;
         }
 
     }

--- a/yuniql-core/Yuniql.Core.xml
+++ b/yuniql-core/Yuniql.Core.xml
@@ -318,6 +318,9 @@
         <member name="M:Yuniql.Core.DirectoryService.FilterFiles(System.String,System.String,System.Collections.Generic.List{System.String})">
             <inheritdoc/>
         </member>
+        <member name="M:Yuniql.Core.DirectoryService.SortFiles(System.String,System.String,System.Collections.Generic.List{System.String})">
+            <inheritdoc/>
+        </member>
         <member name="M:Yuniql.Core.DirectoryService.FilterDirectories(System.String,System.String,System.Collections.Generic.List{System.String})">
             <inheritdoc/>
         </member>
@@ -357,7 +360,7 @@
             Writes trace information into a text file in the current workspace directory. 
             </summary>
         </member>
-        <member name="M:Yuniql.Core.FileTraceService.#ctor(Yuniql.Core.IDirectoryService)">
+        <member name="M:Yuniql.Core.FileTraceService.#ctor">
             <inheritdoc/>
         </member>
         <member name="P:Yuniql.Core.FileTraceService.IsDebugEnabled">
@@ -369,7 +372,10 @@
         <member name="P:Yuniql.Core.FileTraceService.IsTraceToFile">
             <inheritdoc/>
         </member>
-        <member name="P:Yuniql.Core.FileTraceService.TraceToDirectory">
+        <member name="P:Yuniql.Core.FileTraceService.IsTraceToDirectory">
+            <inheritdoc/>
+        </member>
+        <member name="P:Yuniql.Core.FileTraceService.TraceDirectory">
             <inheritdoc/>
         </member>
         <member name="M:Yuniql.Core.FileTraceService.Debug(System.String,System.Object)">
@@ -417,6 +423,33 @@
             <summary>
             Wraps <see cref="M:System.IO.Directory.GetFiles(System.String)"/>
             </summary>
+        </member>
+        <member name="M:Yuniql.Core.IDirectoryService.FilterFiles(System.String,System.String,System.Collections.Generic.List{System.String})">
+            <summary>
+            Returns list of files in the target environment specific directory
+            </summary>
+            <param name="path"></param>
+            <param name="environmentCode"></param>
+            <param name="files"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Yuniql.Core.IDirectoryService.FilterDirectories(System.String,System.String,System.Collections.Generic.List{System.String})">
+            <summary>
+            Not implemented
+            </summary>
+            <param name="path"></param>
+            <param name="environmentCode"></param>
+            <param name="directories"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Yuniql.Core.IDirectoryService.SortFiles(System.String,System.String,System.Collections.Generic.List{System.String})">
+            <summary>
+            Return sorted files based on default sort order or using in-placed sorting manifest _manifest.ini
+            </summary>
+            <param name="path"></param>
+            <param name="environmentCode"></param>
+            <param name="files"></param>
+            <returns></returns>
         </member>
         <member name="M:Yuniql.Core.IDirectoryService.CreateDirectory(System.String)">
             <summary>
@@ -729,6 +762,11 @@
             <summary>
             Retuns verion in v{Major}.{Minor} format.
             Example v0.00 for baseline version.
+            </summary>
+        </member>
+        <member name="P:Yuniql.Core.LocalVersion.Name">
+            <summary>
+            Returns the original version name
             </summary>
         </member>
         <member name="P:Yuniql.Core.LocalVersion.Path">

--- a/yuniql-extensibility/ITraceService.cs
+++ b/yuniql-extensibility/ITraceService.cs
@@ -18,12 +18,17 @@
         /// <summary>
         /// This parameter allows users to define the directory where the log files will be created.
         /// </summary>
-        string TraceToDirectory { get; set; }
+        bool IsTraceToDirectory { get; set; }
 
         /// <summary>
-        /// When true, the log creation is disabled.
+        /// When false, the log file creation is disabled.
         /// </summary>
         bool IsTraceToFile { get; set; }
+
+        /// <summary>
+        /// The directory where log files created will be placed.
+        /// </summary>
+        string TraceDirectory { get; set; }
 
         /// <summary>
         /// Writes debug messages.

--- a/yuniql-extensibility/Yuniql.Extensibility.xml
+++ b/yuniql-extensibility/Yuniql.Extensibility.xml
@@ -528,14 +528,19 @@
             When true, sensitive data is not getting redacted.
             </summary>
         </member>
-        <member name="P:Yuniql.Extensibility.ITraceService.TraceToDirectory">
+        <member name="P:Yuniql.Extensibility.ITraceService.IsTraceToDirectory">
             <summary>
             This parameter allows users to define the directory where the log files will be created.
             </summary>
         </member>
         <member name="P:Yuniql.Extensibility.ITraceService.IsTraceToFile">
             <summary>
-            When true, the log creation is disabled.
+            When false, the log file creation is disabled.
+            </summary>
+        </member>
+        <member name="P:Yuniql.Extensibility.ITraceService.TraceDirectory">
+            <summary>
+            The directory where log files created will be placed.
             </summary>
         </member>
         <member name="M:Yuniql.Extensibility.ITraceService.Debug(System.String,System.Object)">


### PR DESCRIPTION
Notes:
- Fix issues reported on #260 `--trace-to-file` not working
- Set log settings to silent by default and user need to pass `--trace-to-file` to enable log creation
- Added `--trace-directory` to accept custom directory for log files
- Added `--trace-to-directory` to complement the --trace-directory parameter
- Added warning messages on logs when trace silent is enabled
- Added log file path into log message 