### PR TITLE
Issue 223 Upgrade to .Net 6.0 LTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ baseliner/Properties/PublishProfiles/FolderProfile.pubxml.user
 baseliner/Properties/launchSettings.json
 baseliner/Properties/PublishProfiles/FolderProfile.pubxml
 /yuniql-tests/obj
-/yuniql-tests/bin/Debug/netcoreapp3.0
+/yuniql-tests/bin/Debug/net6.0
 /yuniql-tests/.vs
 /yuniql-sqlserver/obj
 /yuniql-sqlserver/bin
@@ -64,10 +64,10 @@ yuniql-plugins/postgresql/.vs/Yuniql.PostgreSQLx/v16/Server/sqlite3/db.lock
 yuniql-plugins/postgresql/.vs/Yuniql.PostgreSQLx/v16/Server/sqlite3/storage.ide
 yuniql-plugins/postgresql/.vs/Yuniql.PostgreSQLx/v16/Server/sqlite3/storage.ide-shm
 yuniql-plugins/postgresql/.vs/Yuniql.PostgreSQLx/v16/Server/sqlite3/storage.ide-wal
-/yuniql-unittests/bin/Debug/netcoreapp3.0
+/yuniql-unittests/bin/Debug/net6.0
 /yuniql-unittests/obj
 /yuniql-platformtests/.vs
-/yuniql-platformtests/bin/Debug/netcoreapp3.0
+/yuniql-platformtests/bin/Debug/net6.0
 /yuniql-platformtests/obj
 /yuniql-core/nupkgs
 /yuniql-extensibility/nupkgs

--- a/samples/postgresql-aspnetcore-sample/postgresql-aspnetcore-sample.csproj
+++ b/samples/postgresql-aspnetcore-sample/postgresql-aspnetcore-sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>aspnetcore_sample</RootNamespace>
   </PropertyGroup>
 

--- a/samples/postgresql-efcore-sample/efsample.csproj
+++ b/samples/postgresql-efcore-sample/efsample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/sqlserver-aspnetcore-sample/aspnetcore-sample.csproj
+++ b/samples/sqlserver-aspnetcore-sample/aspnetcore-sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>aspnetcore_sample</RootNamespace>
   </PropertyGroup>
 

--- a/samples/sqlserver-console-sample/console-sample.csproj
+++ b/samples/sqlserver-console-sample/console-sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>console_sample</RootNamespace>
   </PropertyGroup>
 

--- a/samples/sqlserver-worker-sample/worker-sample.csproj
+++ b/samples/sqlserver-worker-sample/worker-sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dotnet-worker_sample-78E4E90C-A95F-440A-99DE-9799ADDAD480</UserSecretsId>
     <RootNamespace>worker_sample</RootNamespace>
   </PropertyGroup>

--- a/yuniql-cli/README.md
+++ b/yuniql-cli/README.md
@@ -20,7 +20,7 @@ docker run -dit --name yuniql-sqlserver  -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWOR
 Run from CLI
 
 ```console
-cd C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish
+cd C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish
 
 SETX YUNIQL_CONNECTION_STRING "Server=localhost,1400;Database=helloyuniql;User Id=SA;Password=P@ssw0rd!"
 SETX YUNIQL_WORKSPACE "C:\play\yuniql\samples\basic-sqlserver-sample"
@@ -32,7 +32,7 @@ yuniql destroy --force --debug
 ```
 
 ```console
-cd C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish
+cd C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish
 
 yuniql run -a -p C:\play\yuniql\samples\basic-sqlserver-sample -c "Server=localhost,1400;Database=helloyuniql;User Id=SA;Password=P@ssw0rd!" --platform sqlserver --debug
 yuniql list -p C:\play\yuniql\samples\basic-sqlserver-sample -c "Server=localhost,1400;Database=helloyuniql;User Id=SA;Password=P@ssw0rd!" --platform sqlserver --debug

--- a/yuniql-cli/Yuniql.CLI.csproj
+++ b/yuniql-cli/Yuniql.CLI.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.6.0" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/yuniql-cli/Yuniql.CLI.csproj
+++ b/yuniql-cli/Yuniql.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject>Yuniql.CLI.Program</StartupObject>
     <AssemblyName>yuniql</AssemblyName>
     <PackageId>Yuniql.Cli</PackageId>

--- a/yuniql-core/Yuniql.Core.csproj
+++ b/yuniql-core/Yuniql.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject></StartupObject>
     <Company></Company>
     <Version>1.0.0</Version>

--- a/yuniql-distribution/aspnetcore/Yuniql.AspNetCore.csproj
+++ b/yuniql-distribution/aspnetcore/Yuniql.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Authors>Rodel E. Dagumampan</Authors>
     <Description>The package to use for running yuniql-based database migrations inside ASP.NET Core application or service. See WIKI for how-to instructions.</Description>
     <Copyright>Copyright 2019 Rodel E. Dagumampan</Copyright>

--- a/yuniql-extensibility/Yuniql.Extensibility.csproj
+++ b/yuniql-extensibility/Yuniql.Extensibility.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject></StartupObject>
     <PackageId>Yuniql.Extensibility</PackageId>
     <Authors>Rodel E. Dagumampan</Authors>

--- a/yuniql-platforms/mysql/Yuniql.MySql.csproj
+++ b/yuniql-platforms/mysql/Yuniql.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject></StartupObject>

--- a/yuniql-platforms/mysql/Yuniql.MySql.csproj
+++ b/yuniql-platforms/mysql/Yuniql.MySql.csproj
@@ -43,7 +43,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <PackageReference Include="MySql.Data" Version="8.0.28" />
+    <PackageReference Include="MySql.Data" Version="8.0.29" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <None Include="favicon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>

--- a/yuniql-platforms/oracle/Yuniql.Oracle.csproj
+++ b/yuniql-platforms/oracle/Yuniql.Oracle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject></StartupObject>

--- a/yuniql-platforms/oracle/Yuniql.Oracle.csproj
+++ b/yuniql-platforms/oracle/Yuniql.Oracle.csproj
@@ -35,7 +35,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.101" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.50" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <None Include="favicon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>

--- a/yuniql-platforms/postgresql/Yuniql.PostgreSql.csproj
+++ b/yuniql-platforms/postgresql/Yuniql.PostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject></StartupObject>

--- a/yuniql-platforms/postgresql/Yuniql.PostgreSql.csproj
+++ b/yuniql-platforms/postgresql/Yuniql.PostgreSql.csproj
@@ -43,7 +43,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <PackageReference Include="Npgsql" Version="4.1.1" />
+    <PackageReference Include="Npgsql" Version="6.0.4" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <None Include="favicon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>

--- a/yuniql-platforms/redshift/Yuniql.Redshift.csproj
+++ b/yuniql-platforms/redshift/Yuniql.Redshift.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject></StartupObject>

--- a/yuniql-platforms/redshift/Yuniql.Redshift.csproj
+++ b/yuniql-platforms/redshift/Yuniql.Redshift.csproj
@@ -35,7 +35,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <PackageReference Include="Npgsql" Version="4.1.1" />
+    <PackageReference Include="Npgsql" Version="6.0.4" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <None Include="favicon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>

--- a/yuniql-platforms/snowflake/Yuniql.Snowflake.csproj
+++ b/yuniql-platforms/snowflake/Yuniql.Snowflake.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject></StartupObject>

--- a/yuniql-platforms/sqlserver/Yuniql.SqlServer.csproj
+++ b/yuniql-platforms/sqlserver/Yuniql.SqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <StartupObject></StartupObject>
     <Company></Company>
     <Version>1.0.0</Version>

--- a/yuniql-platforms/sqlserver/Yuniql.SqlServer.csproj
+++ b/yuniql-platforms/sqlserver/Yuniql.SqlServer.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/yuniql-tests/platform-tests/README.md
+++ b/yuniql-tests/platform-tests/README.md
@@ -46,7 +46,7 @@ dotnet publish -c release -r win-x64 /p:publishsinglefile=true /p:publishtrimmed
 SETX YUNIQL_TEST_PLATFORM "sqlserver"
 SETX YUNIQL_TEST_CONNECTION_STRING "Server=localhost,1400;Database=yuniqldb;User Id=SA;Password=P@ssw0rd!"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-sqlserver-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCALSERVER"
 ```
 
@@ -75,7 +75,7 @@ dotnet publish -c release -r win-x64 /p:publishsinglefile=true /p:publishtrimmed
 SETX YUNIQL_TEST_PLATFORM "postgresql"
 SETX YUNIQL_TEST_CONNECTION_STRING "Host=localhost;Port=5432;Username=sa;Password=P@ssw0rd!;Database=yuniqldb"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-postgresql-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCALSERVER"
 ```
 
@@ -103,7 +103,7 @@ dotnet publish -c release -r win-x64 /p:publishsinglefile=true /p:publishtrimmed
 SETX YUNIQL_TEST_PLATFORM "mysql"
 SETX YUNIQL_TEST_CONNECTION_STRING "Server=localhost;Port=3306;Database=yuniqldb;Uid=root;Pwd=P@ssw0rd!;"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-mysql-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCALSERVER"
 ```
 
@@ -131,7 +131,7 @@ dotnet publish -c release -r win-x64 /p:publishsinglefile=true /p:publishtrimmed
 SETX YUNIQL_TEST_PLATFORM "mariadb"
 SETX YUNIQL_TEST_CONNECTION_STRING "Server=localhost;Port=3306;Database=yuniqldb;Uid=root;Pwd=P@ssw0rd!;"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-mysql-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCALSERVER"
 ```
 
@@ -155,7 +155,7 @@ dotnet publish -c release -r win-x64 /p:publishsinglefile=true /p:publishtrimmed
 SETX YUNIQL_TEST_PLATFORM "snowflake"
 SETX YUNIQL_TEST_CONNECTION_STRING "host=<your-snowflake-host>;account=<your-snowflake-account>;user=<your-snowflake-user>;password=<your-snowflake-password>;db=yuniqldb;schema=PUBLIC"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-snowflake-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCALSERVER"
 ```
 
@@ -179,7 +179,7 @@ dotnet publish -c release -r win-x64 /p:publishsinglefile=true /p:publishtrimmed
 SETX YUNIQL_TEST_PLATFORM "redshift"
 SETX YUNIQL_TEST_CONNECTION_STRING "<your-redshift-connection-string>"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-redshift-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCALSERVER"
 ```
 
@@ -207,7 +207,7 @@ dotnet publish -c release -r win-x64 /p:publishsinglefile=true /p:publishtrimmed
 SETX YUNIQL_TEST_PLATFORM "oracle"
 SETX YUNIQL_TEST_CONNECTION_STRING "Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=localhost)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=ORCLCDB.localdomain)));User Id=sys;Password=Oradoc_db1;DBA Privilege=SYSDBA;"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-oracle-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCALSERVER"
 ```
 

--- a/yuniql-tests/platform-tests/Setup/DataTestMethodExAttribute.cs
+++ b/yuniql-tests/platform-tests/Setup/DataTestMethodExAttribute.cs
@@ -24,7 +24,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };
@@ -39,7 +39,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };

--- a/yuniql-tests/platform-tests/Setup/TestMethodExAttribute.cs
+++ b/yuniql-tests/platform-tests/Setup/TestMethodExAttribute.cs
@@ -24,7 +24,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };
@@ -40,7 +40,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };
@@ -56,7 +56,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };
@@ -71,7 +71,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };
@@ -85,7 +85,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };
@@ -100,7 +100,7 @@ namespace Yuniql.PlatformTests.Setup
                 {
                     new TestResult
                     {
-                        Outcome = UnitTestOutcome.NotRunnable,
+                        Outcome = UnitTestOutcome.Inconclusive,
                         LogOutput = message
                     }
                 };

--- a/yuniql-tests/platform-tests/Yuniql.PlatformTests.csproj
+++ b/yuniql-tests/platform-tests/Yuniql.PlatformTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/yuniql-tests/platform-tests/Yuniql.PlatformTests.csproj
+++ b/yuniql-tests/platform-tests/Yuniql.PlatformTests.csproj
@@ -9,14 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="MySql.Data" Version="8.0.28" />
-    <PackageReference Include="Npgsql" Version="4.1.1" />
-    <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MySql.Data" Version="8.0.29" />
+    <PackageReference Include="Npgsql" Version="6.0.4" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/yuniql-tests/platform-tests/run_mariadb.bat
+++ b/yuniql-tests/platform-tests/run_mariadb.bat
@@ -4,7 +4,7 @@ echo "-------- Preparing environment variables"
 SETX YUNIQL_TEST_PLATFORM "mariadb"
 SETX YUNIQL_TEST_CONNECTION_STRING "Server=localhost;Port=3306;Database=yuniqldb;Uid=root;Pwd=P@ssw0rd!;"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql-dev\samples\basic-mysql-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql-dev\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql-dev\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCAL"
 
 echo "-------- Provisioning test database on docker container"

--- a/yuniql-tests/platform-tests/run_mysql.bat
+++ b/yuniql-tests/platform-tests/run_mysql.bat
@@ -4,7 +4,7 @@ echo "-------- Preparing environment variables"
 SETX YUNIQL_TEST_PLATFORM "mysql"
 SETX YUNIQL_TEST_CONNECTION_STRING "Server=localhost;Port=3306;Database=yuniqldb;Uid=root;Pwd=P@ssw0rd!;"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-mysql-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCAL"
 
 echo "-------- Provisioning test database on docker container"

--- a/yuniql-tests/platform-tests/run_postgresql.bat
+++ b/yuniql-tests/platform-tests/run_postgresql.bat
@@ -4,7 +4,7 @@ echo "-------- Preparing environment variables"
 SETX YUNIQL_TEST_PLATFORM "postgresql"
 SETX YUNIQL_TEST_CONNECTION_STRING "Host=localhost;Port=5432;Username=sa;Password=P@ssw0rd!;Database=yuniqldb"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-postgresql-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCAL"
 
 echo "-------- Provisioning test database on docker container"

--- a/yuniql-tests/platform-tests/run_sqlserver.bat
+++ b/yuniql-tests/platform-tests/run_sqlserver.bat
@@ -4,7 +4,7 @@ echo "-------- Preparing environment variables"
 SETX YUNIQL_TEST_PLATFORM "sqlserver"
 SETX YUNIQL_TEST_CONNECTION_STRING "Server=localhost,1400;Database=yuniqldb;User Id=SA;Password=P@ssw0rd!"
 SETX YUNIQL_TEST_SAMPLEDB "C:\play\yuniql\samples\basic-sqlserver-sample"
-SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\netcoreapp3.0\win-x64\publish"
+SETX YUNIQL_TEST_CLI "C:\play\yuniql\yuniql-cli\bin\release\net6.0\win-x64\publish"
 SETX YUNIQL_TEST_HOST "LOCAL"
 
 echo "-------- Provisioning test database on docker container"

--- a/yuniql-tests/unit-tests/Tests/ConfigurationServiceTests.cs
+++ b/yuniql-tests/unit-tests/Tests/ConfigurationServiceTests.cs
@@ -73,6 +73,9 @@ namespace Yuniql.UnitTests
             var traceService = new Mock<ITraceService>();
             var workspaceService = new Mock<IWorkspaceService>();
 
+            //disable IsTraceSensitiveData to log plain text connection strings
+            traceService.Setup(property => property.IsTraceSensitiveData).Returns(false);
+
             var parameters = GetFreshConfiguration();
             var environmentService = new Mock<IEnvironmentService>();
             environmentService.Setup(s => s.GetEnvironmentVariable(ENVIRONMENT_VARIABLE.YUNIQL_WORKSPACE)).Returns(parameters.Workspace);
@@ -85,8 +88,7 @@ namespace Yuniql.UnitTests
             var configurationJson = sut.PrintAsJson();
 
             //assert
-            var configuration = JsonSerializer.Deserialize<Configuration>(configurationJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            configuration.ConnectionString.ShouldBe("<sensitive-data-redacted>");
+            configurationJson.Contains("\"connectionString\": \"<sensitive-data-redacted>\"").ShouldBeTrue();
         }
 
         [TestMethod]
@@ -96,7 +98,8 @@ namespace Yuniql.UnitTests
             var traceService = new Mock<ITraceService>();
             var workspaceService = new Mock<IWorkspaceService>();
 
-            traceService.Setup(property => property.IsTraceSensitiveData).Returns(true); //Enable TraceSensitiveData for the current test
+            //enable IsTraceSensitiveData to log plain text connection strings
+            traceService.Setup(property => property.IsTraceSensitiveData).Returns(true); 
 
             var parameters = GetFreshConfiguration();
 
@@ -111,8 +114,7 @@ namespace Yuniql.UnitTests
             var configurationJson = sut.PrintAsJson();
 
             //assert
-            var configuration = JsonSerializer.Deserialize<Configuration>(configurationJson, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            configuration.ConnectionString.ShouldBe(parameters.ConnectionString);
+            configurationJson.Contains("\"connectionString\": \"<sensitive-data-redacted>\"").ShouldBeFalse ();
         }
 
         [TestMethod]

--- a/yuniql-tests/unit-tests/Yuniql.UnitTests.csproj
+++ b/yuniql-tests/unit-tests/Yuniql.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/yuniql-tests/unit-tests/Yuniql.UnitTests.csproj
+++ b/yuniql-tests/unit-tests/Yuniql.UnitTests.csproj
@@ -9,12 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Shouldly" Version="4.0.0-beta0002" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" Version="4.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded all projects to use .net 6 and updated all referenced assemblies to their latest versions.

I ran the SQL Server test, 9 of which failed.
![Test Result](https://user-images.githubusercontent.com/22476720/166233396-ca4cc19f-c2da-4dfb-b9d1-b00a06ffec5d.png)

```
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
  Failed Test_Run_Fail_Migration_When_Version_Directory_With_Explicit_Transaction_Has_Other_Directories
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Fail_Migration_When_Version_With_Explicit_Transaction_Directory_Has_Files
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Fail_Migration_When_DDL_Failed_And_Transactional_DDL_Not_Supported
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Fail_Migration_When_No_Force_Continue_After_Failue_Option_Enabled
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Ok_Migration_With_Force_Continue_After_Failue_Option_Enabled
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Ok_Without_Explicit_Transaction
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Ok_With_Explicit_Transaction
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Ok_Without_Explicit_Transaction_With_SubDirectories
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.

  Failed Test_Run_Ok_With_Explicit_Transaction_With_SubDirectories
  Standard Output Messages:
 Target database platform or version does not support atomic DDL operations. DDL operations like CREATE TABLE, CREATE VIEW are not gauranteed to be executed transactional.
```