### PR TITLE
Added new docker files for yuniql/cli image to support volume

### DIFF
--- a/yuniql-distribution/docker/dockerfile.multi-stage-linux-x64-cli
+++ b/yuniql-distribution/docker/dockerfile.multi-stage-linux-x64-cli
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+
+WORKDIR /code
+
+# copy all files and directories from root src folder
+COPY . .
+
+WORKDIR /code/yuniql-cli
+RUN dotnet publish -c release -r linux-x64 /p:publishtrimmed=true -o ./app
+
+#https://github.com/dotnet/dotnet-docker/issues/1332
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime-env
+
+WORKDIR app
+COPY --from=build-env /code/yuniql-cli/app .
+
+ENV YUNIQL_WORKSPACE /data
+
+ENTRYPOINT ["dotnet", "yuniql.dll"]
+CMD ["additional-arguments-captured-from-docker-run"]

--- a/yuniql-distribution/docker/dockerfile.multi-stage-win-x64-cli
+++ b/yuniql-distribution/docker/dockerfile.multi-stage-win-x64-cli
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+
+WORKDIR /code
+
+# copy all files and directories from root src folder
+COPY . .
+
+WORKDIR /code/yuniql-cli
+RUN dotnet publish -c release -r win-x64 /p:publishtrimmed=true -o ./app
+
+#https://github.com/dotnet/dotnet-docker/issues/1332
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime-env
+
+WORKDIR app
+COPY --from=build-env /code/yuniql-cli/app .
+
+ENV YUNIQL_WORKSPACE /data
+
+ENTRYPOINT ["dotnet", "yuniql.dll"]
+CMD ["additional-arguments-captured-from-docker-run"]


### PR DESCRIPTION
- Supports mapping local volume as source of db scripts
- Supports all CLI verbs

#### Linux
```
cd c:/play/yuniql
docker build -t yuniql/cli -f dockerfile.multi-stage-linux-x64-cli .
docker tag yuniql/cli yuniql/cli:linux-x64-1.3.2

docker run --rm -v c:/play/yuniql/samples/basic-postgresql-sample:/data yuniql/cli:linux-x64-1.3.2 run --platform postgresql -d  -c "<your-connection-string>"
docker run --rm -v c:/play/yuniql/samples/basic-postgresql-sample:/data yuniql/cli:linux-x64-1.3.2 erase --platform postgresql -d  -c "<your-connection-string>" --force

```

#### Windows
```
cd c:/play/yuniql-issue-234
docker build -t yuniql/cli -f dockerfile.multi-stage-win-x64-cli .
docker tag yuniql/cli yuniql/cli:win-x64-1.3.2

docker run --rm -v c:/play/yuniql/samples/basic-postgresql-sample:c:/data yuniql/cli:win-x64-1.3.2 run --platform postgresql -d  -c "<your-connection-string>"
docker run --rm -v c:/play/yuniql/samples/basic-postgresql-sample:c:/data yuniql/cli:win-x64-1.3.2 erase --platform postgresql -d  -c "<your-connection-string>" --force
```