### PR TITLE
Fixed exit code for version and help commands

### DIFF
--- a/yuniql-cli/Program.cs
+++ b/yuniql-cli/Program.cs
@@ -63,7 +63,7 @@ namespace Yuniql.CLI
                     (BaselineOption opts) => Dispatch(commandLineService.RunBaselineOption, opts, traceService),
                     (RebaseOption opts) => Dispatch(commandLineService.RunRebaseOption, opts, traceService),
                     //(ArchiveOption opts) => Dispatch(commandLineService.RunArchiveOption, opts, traceService)
-                    errs => 1);
+                    errs => errs.IsVersion() || errs.IsHelp() ? 0 : 1);
 
             return resultCode;
         }


### PR DESCRIPTION
I have got a gitlab-ci.yaml  

```
deploy:
  state: deploy
  script:
  - echo "deploy"
  - yuniql version
```

The result of this job is:
```
$ yuniql version
yuniql 1.3.15
ERROR: Job failed: exit status 1
```